### PR TITLE
Use 'head' tag in honeycomb examples

### DIFF
--- a/incubator/honeycomb-agent/examples/sidecar-raw-deployment-object/generated/nginx-deployment.json
+++ b/incubator/honeycomb-agent/examples/sidecar-raw-deployment-object/generated/nginx-deployment.json
@@ -58,7 +58,7 @@
                               }
                            }
                         ],
-                        "image": "honeycombio/honeycomb-kubernetes-agent:1df5484",
+                        "image": "honeycombio/honeycomb-kubernetes-agent:head",
                         "name": "honeycomb-agent",
                         "resources": {
                            "limits": {

--- a/incubator/honeycomb-agent/examples/sidecar-raw-deployment-object/nginx-deployment.jsonnet
+++ b/incubator/honeycomb-agent/examples/sidecar-raw-deployment-object/nginx-deployment.jsonnet
@@ -33,7 +33,7 @@ local mount = container.volumeMountsType;
 local conf = {
   namespace:: "kube-system",
   agent:: {
-    containerTag:: "1df5484",
+    containerTag:: "head",
     containerName:: "honeycomb-agent",
   },
   rbac:: {

--- a/incubator/honeycomb-agent/examples/using-daemonset-builder/generated/honeycomb-daemonset.json
+++ b/incubator/honeycomb-agent/examples/using-daemonset-builder/generated/honeycomb-daemonset.json
@@ -48,7 +48,7 @@
                               }
                            }
                         ],
-                        "image": "honeycombio/honeycomb-kubernetes-agent:1df5484",
+                        "image": "honeycombio/honeycomb-kubernetes-agent:head",
                         "name": "honeycomb-agent",
                         "resources": {
                            "limits": {

--- a/incubator/honeycomb-agent/examples/using-daemonset-builder/honeycomb-daemonset.jsonnet
+++ b/incubator/honeycomb-agent/examples/using-daemonset-builder/honeycomb-daemonset.jsonnet
@@ -22,7 +22,7 @@ local honeycomb = import "incubator/honeycomb-agent/honeycomb-agent.libsonnet";
 local conf = {
   namespace:: "kube-system",
   agent:: {
-    containerTag:: "1df5484",
+    containerTag:: "head",
     containerName:: "honeycomb-agent",
   },
   rbac:: {


### PR DESCRIPTION
In github.com/honeycombio/honeycomb-kubernetes-agent, we're now tagging the
most recent build as `honeycombio/honeycomb-kubernetes-agent:head`. Use that tag
in examples; it's probably most convenient for users to get the latest and
greatest here.

Signed-off-by: Eben Freeman <eben@honeycomb.io>