### PR TITLE
Update libraries to work with `ks dep`

### DIFF
--- a/incubator/apache/apache.libsonnet
+++ b/incubator/apache/apache.libsonnet
@@ -1,4 +1,4 @@
-local k = import "ksonnet.beta.2/k.libsonnet";
+local k = import "k.libsonnet";
 local deployment = k.extensions.v1beta1.deployment;
 
 {

--- a/incubator/apache/examples/apache.jsonnet
+++ b/incubator/apache/examples/apache.jsonnet
@@ -1,4 +1,4 @@
-local k = import "ksonnet.beta.2/k.libsonnet";
+local k = import "k.libsonnet";
 local apache = import "../apache.libsonnet";
 
 

--- a/incubator/apache/parts.yaml
+++ b/incubator/apache/parts.yaml
@@ -1,7 +1,8 @@
 {
-  "name": "nodejs",
-  "version": "0.0.1",
-  "description": "Node is an event-driven I/O server-side JavaScript environment based on V8",
+  "name": "apache",
+  "apiVersion": "0.0.1",
+  "kind": "ksonnet.io/parts",
+  "description": "Apache Ksonnet mixin library contains a simple prototype with pre-configured components to help you deploy a Apache HTTP Server app to a Kubernetes cluster with ease.",
   "author": "ksonnet team <ksonnet-help@heptio.com>",
   "contributors": [
     {
@@ -21,19 +22,19 @@
     "url": "https://github.com/ksonnet/mixins/issues"
   },
   "keywords": [
-    "nodejs",
-    "node",
+    "apache",
     "server",
-    "javascript"
+    "http"
   ],
   "quickStart": {
-    "prototype": "io.ksonnet.pkg.nodejs-simple",
-    "componentName": "nodejs",
+    "prototype": "io.ksonnet.pkg.apache-simple",
+    "componentName": "apache",
     "flags": {
-      "name": "nodejs",
+      "name": "apache",
       "namespace": "default"
     },
-    "comment": "Run a simple node.js server"
+    "comment": "Run a simple NGINX server"
   },
   "license": "Apache 2.0"
 }
+

--- a/incubator/apache/prototypes/apache-simple.jsonnet
+++ b/incubator/apache/prototypes/apache-simple.jsonnet
@@ -5,7 +5,7 @@
 // @param namespace string Namespace to divvy up your cluster; default is 'default'
 // @param name string Name to identify all Kubernetes objects in this prototype
 
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local apache = import 'incubator/apache/apache.libsonnet';
 
 local namespace = import 'param://namespace';

--- a/incubator/honeycomb-agent/examples/sidecar-raw-deployment-object/nginx-deployment.jsonnet
+++ b/incubator/honeycomb-agent/examples/sidecar-raw-deployment-object/nginx-deployment.jsonnet
@@ -15,7 +15,7 @@
 // NOTE: For these imports you must invoke the Jsonnet CLI with -J
 // flags pointing at (1) the ksonnet library root, and (2) the root
 // of the mixins repository.
-local k = import "ksonnet.beta.2/k.libsonnet";
+local k = import "k.libsonnet";
 local honeycomb = import "incubator/honeycomb-agent/honeycomb-agent.libsonnet";
 
 // Destructure imports.

--- a/incubator/honeycomb-agent/examples/using-daemonset-builder/honeycomb-daemonset.jsonnet
+++ b/incubator/honeycomb-agent/examples/using-daemonset-builder/honeycomb-daemonset.jsonnet
@@ -14,7 +14,7 @@
 // NOTE: For these imports you must invoke the Jsonnet CLI with -J
 // flags pointing at (1) the ksonnet library root, and (2) the root
 // of the mixins repository.
-local k = import "ksonnet.beta.2/k.libsonnet";
+local k = import "k.libsonnet";
 local honeycomb = import "incubator/honeycomb-agent/honeycomb-agent.libsonnet";
 
 // Configuration. Specifies how to set up the DaemonSet and Honeycomb

--- a/incubator/honeycomb-agent/examples/using-daemonset-builder/nginx-app.jsonnet
+++ b/incubator/honeycomb-agent/examples/using-daemonset-builder/nginx-app.jsonnet
@@ -1,4 +1,4 @@
-local k = import "ksonnet.beta.2/k.libsonnet";
+local k = import "k.libsonnet";
 
 // Destructure the imports.
 local container = k.extensions.v1beta1.deployment.mixin.spec.template.spec.containersType;

--- a/incubator/honeycomb-agent/honeycomb-agent.libsonnet
+++ b/incubator/honeycomb-agent/honeycomb-agent.libsonnet
@@ -1,4 +1,4 @@
-local k = import "ksonnet.beta.2/k.libsonnet";
+local k = import "k.libsonnet";
 
 // Destructuring imports for base.
 local ds = k.extensions.v1beta1.daemonSet;

--- a/incubator/mariadb/examples/maria.jsonnet
+++ b/incubator/mariadb/examples/maria.jsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local maria = import '../maria.libsonnet';
 
 k.core.v1.list.new([

--- a/incubator/mariadb/maria.libsonnet
+++ b/incubator/mariadb/maria.libsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local deployment = k.extensions.v1beta1.deployment;
 
 {

--- a/incubator/mariadb/parts.yaml
+++ b/incubator/mariadb/parts.yaml
@@ -1,6 +1,7 @@
 {
   "name": "mariadb",
-  "version": "0.0.1",
+  "apiVersion": "0.0.1",
+  "kind": "ksonnet.io/parts",
   "description": "MariaDB is an open source relational database it provides a SQL interface for accessing data. The latest versions of MariaDB also include GIS and JSON features. This package deploys a maria container, a service and secret to your cluster",
   "author": "ksonnet team <ksonnet-help@heptio.com>",
   "contributors": [
@@ -37,3 +38,4 @@
   },
   "license": "Apache 2.0"
 }
+

--- a/incubator/mariadb/prototypes/maria-stateless.jsonnet
+++ b/incubator/mariadb/prototypes/maria-stateless.jsonnet
@@ -7,7 +7,7 @@
 // @param name string Metadata name for each of the deployment components
 // @param mariaRootPassword string Password for root user
 
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local maria = import 'incubator/mariadb/maria.libsonnet';
 
 local namespace = "import 'param://namespace'";

--- a/incubator/memcached/examples/memcached.jsonnet
+++ b/incubator/memcached/examples/memcached.jsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local memcached = import '../memcached.libsonnet';
 
 local myNamespace = "dev-alex";

--- a/incubator/memcached/memcached.libsonnet
+++ b/incubator/memcached/memcached.libsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 
 {
   parts:: {

--- a/incubator/memcached/parts.yaml
+++ b/incubator/memcached/parts.yaml
@@ -1,7 +1,8 @@
 {
-  "name": "apache",
-  "version": "0.0.1",
-  "description": "Apache Ksonnet mixin library contains a simple prototype with pre-configured components to help you deploy a Apache HTTP Server app to a Kubernetes cluster with ease.",
+  "name": "memcached",
+  "apiVersion": "0.0.1",
+  "kind": "ksonnet.io/parts",
+  "description": "Memcached is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.",
   "author": "ksonnet team <ksonnet-help@heptio.com>",
   "contributors": [
     {
@@ -21,18 +22,19 @@
     "url": "https://github.com/ksonnet/mixins/issues"
   },
   "keywords": [
-    "apache",
-    "server",
-    "http"
+    "memcached",
+    "database",
+    "cache"
   ],
   "quickStart": {
-    "prototype": "io.ksonnet.pkg.apache-simple",
-    "componentName": "apache",
+    "prototype": "io.ksonnet.pkg.memcached-simple",
+    "componentName": "memcached",
     "flags": {
-      "name": "apache",
+      "name": "memcached",
       "namespace": "default"
     },
-    "comment": "Run a simple NGINX server"
+    "comment": "Run a simple memcached instance"
   },
   "license": "Apache 2.0"
 }
+

--- a/incubator/memcached/prototypes/memcached-simple.jsonnet
+++ b/incubator/memcached/prototypes/memcached-simple.jsonnet
@@ -8,7 +8,7 @@
 
 // TODO: Add MaxItemMemory=64 as a param like the k8s/charts?
 
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local memcached = import 'incubator/memcached/memcached.libsonnet';
 
 local namespace = import 'param://namespace';

--- a/incubator/mongodb/examples/mongodb.jsonnet
+++ b/incubator/mongodb/examples/mongodb.jsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local mongo = import '../mongodb.libsonnet';
 
 local namespace = "dev-alex";

--- a/incubator/mongodb/mongodb.libsonnet
+++ b/incubator/mongodb/mongodb.libsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local deployment = k.extensions.v1beta1.deployment;
 
 {

--- a/incubator/mongodb/parts.yaml
+++ b/incubator/mongodb/parts.yaml
@@ -1,6 +1,7 @@
 {
   "name": "mongodb",
-  "version": "0.0.1",
+  "apiVersion": "0.0.1",
+  "kind": "ksonnet.io/parts",
   "description": "MongoDB is a cross-platform document-oriented database. Classified as a NoSQL database, MongoDB eschews the traditional table-based relational database structure in favor of JSON-like documents with dynamic schemas, making the integration of data in certain types of applications easier and faster.",
   "author": "ksonnet team <ksonnet-help@heptio.com>",
   "contributors": [
@@ -39,3 +40,4 @@
   },
   "license": "Apache 2.0"
 }
+

--- a/incubator/mongodb/prototype/mongodb-simple.jsonnet
+++ b/incubator/mongodb/prototype/mongodb-simple.jsonnet
@@ -8,7 +8,7 @@
 // @param rootPassword string RootPassword for db admin password
 // @param password string Password for db user password
 
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local mongo = import 'incubator/mongodb/mongodb.libsonnet';
 
 local namespace = "import 'param://namespace/'";

--- a/incubator/mysql/examples/mysql.jsonnet
+++ b/incubator/mysql/examples/mysql.jsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local mql = import "../mysql.libsonnet";
 
 

--- a/incubator/mysql/mysql.libsonnet
+++ b/incubator/mysql/mysql.libsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 
 {
   parts:: {

--- a/incubator/mysql/parts.yaml
+++ b/incubator/mysql/parts.yaml
@@ -1,7 +1,8 @@
 {
-  "name": "memcached",
-  "version": "0.0.1",
-  "description": "Memcached is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.",
+  "name": "mysql",
+  "apiVersion": "0.0.1",
+  "kind": "ksonnet.io/parts",
+  "description": "MySQL is one of the most popular database servers in the world. Notable users include Wikipedia, Facebook and Google.",
   "author": "ksonnet team <ksonnet-help@heptio.com>",
   "contributors": [
     {
@@ -21,18 +22,19 @@
     "url": "https://github.com/ksonnet/mixins/issues"
   },
   "keywords": [
-    "memcached",
+    "mysql",
     "database",
-    "cache"
+    "relational"
   ],
   "quickStart": {
-    "prototype": "io.ksonnet.pkg.memcached-simple",
-    "componentName": "memcached",
+    "prototype": "io.ksonnet.pkg.simple-mysql",
+    "componentName": "mysql",
     "flags": {
-      "name": "memcached",
+      "name": "mysql",
       "namespace": "default"
     },
-    "comment": "Run a simple memcached instance"
+    "comment": "Run a simple NGINX server"
   },
   "license": "Apache 2.0"
 }
+

--- a/incubator/mysql/prototypes/simple-mysql.jsonnet
+++ b/incubator/mysql/prototypes/simple-mysql.jsonnet
@@ -8,7 +8,7 @@
 // @param mysqlRootPassword string Password for root user
 // @param mysqlPassword string Password for new user
 
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local mysql = import '../mysql.libsonnet';
 
 local namespace = import 'param://namespace';

--- a/incubator/nginx/examples/nginx.jsonnet
+++ b/incubator/nginx/examples/nginx.jsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local nginx = import '../nginx.libsonnet';
 
 local namespace = "dev-alex";

--- a/incubator/nginx/nginx.libsonnet
+++ b/incubator/nginx/nginx.libsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local deployment = k.extensions.v1beta1.deployment;
 local container = deployment.mixin.spec.template.spec.containersType;
 

--- a/incubator/nginx/parts.yaml
+++ b/incubator/nginx/parts.yaml
@@ -38,3 +38,4 @@
   },
   "license": "Apache 2.0"
 }
+

--- a/incubator/nginx/prototypes/nginx-server-block.jsonnet
+++ b/incubator/nginx/prototypes/nginx-server-block.jsonnet
@@ -8,7 +8,7 @@
 
 // TODO: How should the ServerBlockConf be exposed to the user? Not quite sure what the default does except for setting web server to port 80.
 
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local nginx = import 'incubator/nginx/nginx.libsonnet';
 
 local namespace = import 'param://namespace';

--- a/incubator/nginx/prototypes/nginx-simple.jsonnet
+++ b/incubator/nginx/prototypes/nginx-simple.jsonnet
@@ -7,7 +7,7 @@
 // @param name string Name to give to each of the components
 
 
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local nginx = import 'incubator/nginx/nginx.libsonnet';
 
 local namespace = import 'param://namespace';

--- a/incubator/node/nodejs.libsonnet
+++ b/incubator/node/nodejs.libsonnet
@@ -1,4 +1,4 @@
-local k = import "ksonnet.beta.2/k.libsonnet";
+local k = import "k.libsonnet";
 local deployment = k.extensions.v1beta1.deployment;
 
 {

--- a/incubator/node/parts.yaml
+++ b/incubator/node/parts.yaml
@@ -1,7 +1,8 @@
 {
-  "name": "mysql",
-  "version": "0.0.1",
-  "description": "MySQL is one of the most popular database servers in the world. Notable users include Wikipedia, Facebook and Google.",
+  "name": "nodejs",
+  "apiVersion": "0.0.1",
+  "kind": "ksonnet.io/parts",
+  "description": "Node is an event-driven I/O server-side JavaScript environment based on V8",
   "author": "ksonnet team <ksonnet-help@heptio.com>",
   "contributors": [
     {
@@ -21,18 +22,20 @@
     "url": "https://github.com/ksonnet/mixins/issues"
   },
   "keywords": [
-    "mysql",
-    "database",
-    "relational"
+    "nodejs",
+    "node",
+    "server",
+    "javascript"
   ],
   "quickStart": {
-    "prototype": "io.ksonnet.pkg.simple-mysql",
-    "componentName": "mysql",
+    "prototype": "io.ksonnet.pkg.nodejs-simple",
+    "componentName": "nodejs",
     "flags": {
-      "name": "mysql",
+      "name": "nodejs",
       "namespace": "default"
     },
-    "comment": "Run a simple NGINX server"
+    "comment": "Run a simple node.js server"
   },
   "license": "Apache 2.0"
 }
+

--- a/incubator/node/prototypes/nodejs-nonpersistent.jsonnet
+++ b/incubator/node/prototypes/nodejs-nonpersistent.jsonnet
@@ -5,7 +5,7 @@
 // @param namespace string Namespace to specify location of app; default is 'default'
 // @param name string Name of app to identify all K8s objects in this prototype
 
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local nodeJS = import 'incubator/node/nodejs.libsonnet';
 
 local namespace = import 'param://namespace';

--- a/incubator/node/prototypes/nodejs-simple.jsonnet
+++ b/incubator/node/prototypes/nodejs-simple.jsonnet
@@ -6,7 +6,7 @@
 // @param name string Name of app to identify all K8s objects in this prototype
 
 
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local nodeJS = import 'incubator/node/nodejs.libsonnet';
 
 local appName = import 'param://name';

--- a/incubator/postgres/examples/postgres.jsonnet
+++ b/incubator/postgres/examples/postgres.jsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local service = k.core.v1.service.mixin;
 local psg = import '../postgres.libsonnet';
 

--- a/incubator/postgres/parts.yaml
+++ b/incubator/postgres/parts.yaml
@@ -1,6 +1,7 @@
 {
   "name": "postgres",
-  "version": "0.0.1",
+  "apiVersion": "0.0.1",
+  "kind": "ksonnet.io/parts",
   "description": "PostgreSQL is a powerful, open source object-relational database system. It has more than 15 years of active development and a proven architecture that has earned it a strong reputation for reliability, data integrity, and correctness.",
   "author": "ksonnet team <ksonnet-help@heptio.com>",
   "contributors": [
@@ -36,3 +37,4 @@
   },
   "license": "Apache 2.0"
 }
+

--- a/incubator/postgres/postgres.libsonnet
+++ b/incubator/postgres/postgres.libsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local service = k.core.v1.service.mixin;
 
 {

--- a/incubator/postgres/prototypes/postgres-simple.jsonnet
+++ b/incubator/postgres/prototypes/postgres-simple.jsonnet
@@ -7,7 +7,7 @@
 // @param namespace string Namespace to specify destination in cluster; default is 'default'
 // @param password string Password for the root/admin user.
 
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local psg = import 'incubator/postgres/postgres.libsonnet';
 
 local appName = import 'param://name';

--- a/incubator/redis/examples/redis.jsonnet
+++ b/incubator/redis/examples/redis.jsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local redis = import '../redis.libsonnet';
 
 k.core.v1.list.new([

--- a/incubator/redis/parts.yaml
+++ b/incubator/redis/parts.yaml
@@ -38,3 +38,4 @@
   },
   "license": "Apache 2.0"
 }
+

--- a/incubator/redis/prototypes/redis-persistent.jsonnet
+++ b/incubator/redis/prototypes/redis-persistent.jsonnet
@@ -7,7 +7,7 @@
 // @param name string Name to give to each of the components
 // @param redisPassword string User password to supply to redis
 
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local redis = import 'incubator/redis/redis.libsonnet';
 
 local namespace = import 'param://namespace';

--- a/incubator/redis/prototypes/redis-persistent.jsonnet
+++ b/incubator/redis/prototypes/redis-persistent.jsonnet
@@ -14,9 +14,17 @@ local namespace = import 'param://namespace';
 local name = import 'param://name';
 local redisPassword = import 'param://redisPassword';
 
-k.core.v1.list.new([
-  redis.parts.deployment.persistent(namespace, name, name),
+local secretName =
+  if redisPassword != null then name else null;
+
+local optionalSecret =
+  if redisPassword != null
+  then redis.parts.secret(namespace, name, redisPassword)
+  else null;
+
+std.prune((k.core.v1.list.new([
+  redis.parts.deployment.persistent(namespace, name, secretName),
   redis.parts.pvc(namespace, name),
-  redis.parts.secret(namespace, name, redisPassword),
   redis.parts.svc.metricDisabled(namespace, name),
-])
+  optionalSecret,
+]))

--- a/incubator/redis/prototypes/redis-stateless.jsonnet
+++ b/incubator/redis/prototypes/redis-stateless.jsonnet
@@ -7,12 +7,12 @@
 // @param name string Name to give to each of the components.
 // @param redisPassword string User password to supply to redis
 
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local redis = import 'incubator/redis/redis.libsonnet';
 
 local namespace = import 'param://namespace';
 local name = import 'param://name';
-local redisPassword = import 'param://tomcatPassword';
+local redisPassword = import 'param://redisPassword';
 
 k.core.v1.list.new([
   redis.parts.deployment.nonPersistent(namespace, name, name),

--- a/incubator/redis/prototypes/redis-stateless.jsonnet
+++ b/incubator/redis/prototypes/redis-stateless.jsonnet
@@ -14,8 +14,16 @@ local namespace = import 'param://namespace';
 local name = import 'param://name';
 local redisPassword = import 'param://redisPassword';
 
-k.core.v1.list.new([
-  redis.parts.deployment.nonPersistent(namespace, name, name),
-  redis.parts.secret(namespace, name, redisPassword),
+local secretName =
+  if redisPassword != null then name else null;
+
+local optionalSecret =
+  if redisPassword != null
+  then redis.parts.secret(namespace, name, redisPassword)
+  else null;
+
+std.prune(k.core.v1.list.new([
+  redis.parts.deployment.nonPersistent(namespace, name, secretName),
   redis.parts.svc.metricDisabled(namespace, name),
-])
+  optionalSecret,
+]))

--- a/incubator/redis/redis.libsonnet
+++ b/incubator/redis/redis.libsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local deployment = k.extensions.v1beta1.deployment;
 local container = deployment.mixin.spec.template.spec.containersType;
 local storageClass = k.storage.v1beta1.storageClass;

--- a/incubator/registry.yaml
+++ b/incubator/registry.yaml
@@ -2,13 +2,45 @@
   "apiVersion": "0.1",
   "kind": "ksonnet.io/registry",
   "libraries": {
+    "apache": {
+      "version": "test-reg",
+      "path": "apache"
+    },
+    "mariadb": {
+      "version": "test-reg",
+      "path": "mariadb"
+    },
+    "memcached": {
+      "version": "test-reg",
+      "path": "memcached"
+    },
+    "mongodb": {
+      "version": "test-reg",
+      "path": "mongodb"
+    },
+    "mysql": {
+      "version": "test-reg",
+      "path": "mysql"
+    },
+    "node": {
+      "version": "test-reg",
+      "path": "node"
+    },
     "nginx": {
       "version": "test-reg",
       "path": "nginx"
     },
+    "postgres": {
+      "version": "test-reg",
+      "path": "postgres"
+    },
     "redis": {
       "version": "test-reg",
       "path": "redis"
+    },    
+    "tomcat": {
+      "version": "test-reg",
+      "path": "tomcat"
     }
   }
 }

--- a/incubator/tomcat/examples/tomcat.jsonnet
+++ b/incubator/tomcat/examples/tomcat.jsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local tc = import '../tomcat.libsonnet';
 
 

--- a/incubator/tomcat/parts.yaml
+++ b/incubator/tomcat/parts.yaml
@@ -1,6 +1,7 @@
 {
   "name": "tomcat",
-  "version": "0.0.1",
+  "apiVersion": "0.0.1",
+  "kind": "ksonnet.io/parts",
   "description": "Apache Tomcat, or Tomcat, is an open-source web server and servlet container. This package deploys a stateless tomcat container, service, and secret to your cluster",
   "author": "ksonnet team <ksonnet-help@heptio.com>",
   "contributors": [
@@ -38,3 +39,4 @@
   },
   "license": "Apache 2.0"
 }
+

--- a/incubator/tomcat/prototypes/tomcat-persistent.jsonnet
+++ b/incubator/tomcat/prototypes/tomcat-persistent.jsonnet
@@ -8,7 +8,7 @@
 // @param tomcatUser string Username for tomcat manager page, if not specified tomcat will not assign users
 // @param tomcatPassword string Tomcat manager page password, to be encrypted and included in Secret API object
 
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local tc = import 'incubator/tomcat/tomcat.libsonnet';
 
 local namespace = "import 'param://namespace'";

--- a/incubator/tomcat/prototypes/tomcat-stateless.jsonnet
+++ b/incubator/tomcat/prototypes/tomcat-stateless.jsonnet
@@ -7,7 +7,7 @@
 // @param tomcatUser string Username for tomcat manager page, if not specified tomcat will not assign users
 // @param tomcatPassword string Tomcat manager page password, to be encrypted and included in Secret API object
 
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 local tc = import 'incubator/tomcat/tomcat.libsonnet';
 
 local namespace = "import 'param://namespace'";

--- a/incubator/tomcat/tomcat.libsonnet
+++ b/incubator/tomcat/tomcat.libsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet.beta.2/k.libsonnet';
+local k = import 'k.libsonnet';
 
 {
   parts::{


### PR DESCRIPTION
This change is required for the demo to work properly. Also, some additional Redis changes might be needed pending https://github.com/ksonnet/ksonnet/issues/68 (the question of prototype defaults)

cc @hausdorff @jessicayuen 

**Overview**

* rename all parts metadata files to parts.yaml
* add libraries to registry.yaml and update parts.yaml
* remove ksonnet release prefix from imports
* fix misnamed redis param

Signed-off-by: Jessica Yao <jessica@heptio.com>