### PR TITLE
Fix pvc StorageClassName default

### DIFF
--- a/incubator/postgres/README.md
+++ b/incubator/postgres/README.md
@@ -17,6 +17,9 @@ If you haven't yet created a [ksonnet application](linkToSomewhere), do so using
 Finally, in the ksonnet application directory, run the following:
 
 ```shell
+# Install the postgres pkg.
+$ ks pkg install incubator/postgres@master
+
 # Expand prototype as a Jsonnet file, place in a file in the
 # `components/` directory. (YAML and JSON are also available.)
 $ ks prototype use io.ksonnet.pkg.postgres-simple postgres \
@@ -25,7 +28,7 @@ $ ks prototype use io.ksonnet.pkg.postgres-simple postgres \
   --password boots
 
 # Apply to server.
-$ ks apply -f postgres.jsonnet
+$ ks apply default -c postgres
 ```
 
 ## Using the library

--- a/incubator/postgres/postgres.libsonnet
+++ b/incubator/postgres/postgres.libsonnet
@@ -38,7 +38,7 @@ local service = k.core.v1.service.mixin;
         },
       },
 
-    pvc(namespace, name, storageClassName="-", labels={app:name})::
+    pvc(namespace, name, storageClassName="", labels={app:name})::
       local defaults = {
         accessMode:"ReadWriteOnce",
         size: "8Gi"


### PR DESCRIPTION
The default `"-"` is not a valid `StorageClassName`. Switch it to use
`""` as the default instead, which will cause us to use a pre-provisioned PersistentVolume.

Additionally, update the `README.md` instructions for quick starting so
that, when coupled with the change above, the demo works.